### PR TITLE
Add WhatsApp message event tracking

### DIFF
--- a/internal/contacts/contacts.go
+++ b/internal/contacts/contacts.go
@@ -17,15 +17,16 @@ func NewRepository(db *pgxpool.Pool) *Repository {
 }
 
 // Upsert inserts or updates a contact.
-func (r *Repository) Upsert(ctx context.Context, companyID, jid, name, phone string) error {
+func (r *Repository) Upsert(ctx context.Context, companyID, jid, name, phone, avatarURL string) error {
 	_, err := r.db.Exec(ctx, `
-        INSERT INTO contacts (jid, company_id, name, phone, last_seen)
-        VALUES ($1, $2, $3, $4, now())
+        INSERT INTO contacts (jid, company_id, name, phone, avatar_url, last_seen)
+        VALUES ($1, $2, $3, $4, $5, now())
         ON CONFLICT (jid) DO UPDATE
             SET name = COALESCE(EXCLUDED.name, contacts.name),
                 phone = COALESCE(EXCLUDED.phone, contacts.phone),
+                avatar_url = COALESCE(EXCLUDED.avatar_url, contacts.avatar_url),
                 last_seen = now(),
                 updated_at = now()
-    `, jid, companyID, name, phone)
+    `, jid, companyID, name, phone, avatarURL)
 	return err
 }

--- a/internal/db/migrations/0005_add_message_payload_status.sql
+++ b/internal/db/migrations/0005_add_message_payload_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE messages
+    ADD COLUMN payload JSONB,
+    ADD COLUMN status TEXT DEFAULT 'received',
+    ADD COLUMN updated_at TIMESTAMP WITH TIME ZONE DEFAULT now();
+CREATE INDEX IF NOT EXISTS messages_msg_id_idx ON messages(msg_id);

--- a/internal/db/migrations/0006_add_contact_avatar.sql
+++ b/internal/db/migrations/0006_add_contact_avatar.sql
@@ -1,0 +1,2 @@
+ALTER TABLE contacts
+    ADD COLUMN avatar_url TEXT;

--- a/internal/messages/messages.go
+++ b/internal/messages/messages.go
@@ -17,11 +17,20 @@ func NewRepository(db *pgxpool.Pool) *Repository {
 }
 
 // Save inserts a message record.
-func (r *Repository) Save(ctx context.Context, companyID, msgID, sender, receiver, msgType, content string) error {
+func (r *Repository) Save(ctx context.Context, companyID, msgID, sender, receiver, msgType, content, payload, status string) error {
 	_, err := r.db.Exec(ctx,
-		`INSERT INTO messages (company_id, msg_id, sender, receiver, type, content)
-         VALUES ($1, $2, $3, $4, $5, $6)`,
-		companyID, msgID, sender, receiver, msgType, content,
+		`INSERT INTO messages (company_id, msg_id, sender, receiver, type, content, payload, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+		companyID, msgID, sender, receiver, msgType, content, payload, status,
+	)
+	return err
+}
+
+// UpdateStatus updates the status of a message
+func (r *Repository) UpdateStatus(ctx context.Context, companyID, msgID, status string) error {
+	_, err := r.db.Exec(ctx,
+		`UPDATE messages SET status=$1, updated_at=now() WHERE company_id=$2 AND msg_id=$3`,
+		status, companyID, msgID,
 	)
 	return err
 }


### PR DESCRIPTION
## Summary
- persist message payload and status in new columns
- store contact avatar URL when saving contacts
- update WhatsApp service to record edits, deletions and receipts
- add migrations for new database fields

## Testing
- `go vet ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6883c1613d34832b8c04dd2ba07de1ac